### PR TITLE
[CCF-11963] Build notebooks dist archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 .pytest_cache
 .tox
 _venv
+dist
 *BranchRevision.json

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: install dev.test test dist
+
 install:
 	pip install -r requirements-dev.txt
 
@@ -9,5 +11,8 @@ dev.test:
 test:
 	tox -r
 
-zipit:
-	zip -r  cortex-skill-lab-examples.zip . -x *.git*
+dist:
+	mkdir -p dist && \
+	cd cortex_docs_examples && \
+	zip -r ../dist/notebooks.zip . && \
+	cd -

--- a/c12e-ci.yml
+++ b/c12e-ci.yml
@@ -3,6 +3,7 @@ builder:
   command: bash -cx 'apt-get update
     && apt-get install -y libmagic-dev gcc make
     && make install
-    && make test'
+    && make test
+    && make dist'
   environment:
     - TOX_ENV_REQUIREMENTS


### PR DESCRIPTION
Add a 'dist' makefile target which zips up the notebooks we want to include in the Cortex docs.  Separate PRs will have gocd-pipeline-scripts and gocd-pipeline changes to consume this output.