### PR TITLE
fix online-prediction dockerfile base image that is failing tests against dci-dev

### DIFF
--- a/online-prediction/Dockerfile
+++ b/online-prediction/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 ADD . /app
 WORKDIR /app
 RUN pip install -r requirements.txt


### PR DESCRIPTION
The `python:3.11.0a5-slim-bullseye` image was automatically recommended by the snyk/dependabot automated PR but when the integration tests to build this image were run against `dci-dev`, the `docker build` failed with the following error 
```
Could not find a version that satisfies the requirement pandas==1.0.5
```

That version of pandas exists but not for python `3.11.0` :(

Also created https://cognitivescale.atlassian.net/browse/FAB-3999 to make a "linting" pipeline to surface these types of issues sooner.