### PR TITLE
Updating pandas version, reverting python base image to 3.9.10-bullseye

### DIFF
--- a/ai-missions/high-risk-flu-shot-mission/skills/send_engage_sydneycare_chatbot_notification/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_engage_sydneycare_chatbot_notification/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
-
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
+    
 ADD . /code
 
 WORKDIR /code

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_engage_sydneycare_chatbot_notification/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_engage_sydneycare_chatbot_notification/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_nurseline_notification/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_nurseline_notification/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
 
 ADD . /code
 

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_nurseline_notification/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_nurseline_notification/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_schedule_appointment_notification/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_schedule_appointment_notification/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
 
 ADD . /code
 

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_schedule_appointment_notification/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_schedule_appointment_notification/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_sydneycare_notification/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_sydneycare_notification/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
 
 ADD . /code
 

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_sydneycare_notification/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_sydneycare_notification/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_virtual_care_notification/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_virtual_care_notification/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
 
 ADD . /code
 

--- a/ai-missions/high-risk-flu-shot-mission/skills/send_virtual_care_notification/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/send_virtual_care_notification/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2

--- a/ai-missions/high-risk-flu-shot-mission/skills/update_member_phone_number/Dockerfile
+++ b/ai-missions/high-risk-flu-shot-mission/skills/update_member_phone_number/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.9.10-bullseye
 
 ADD requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --upgrade -r requirements.txt \
+    && apt-get purge unzip -y \
+    && apt-get clean
 
 ADD . /code
 

--- a/ai-missions/high-risk-flu-shot-mission/skills/update_member_phone_number/requirements.txt
+++ b/ai-missions/high-risk-flu-shot-mission/skills/update_member_phone_number/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.0.3
+pandas==1.4.1
 cortex-python
 uvicorn==0.12.1
 fastapi==0.65.2


### PR DESCRIPTION
1. `3.11.0a5-slim-bullseye` image builds fail with `/bin/sh: 1: gcc: not found` 
2. Updated pandas version to make use of available `wheels` instead of building

Tested this on DCI-DEV