### PR TITLE
Drop base image to Python 3.8 for model training in EndToEnd example

### DIFF
--- a/EndToEndExample/actions/train/Dockerfile
+++ b/EndToEndExample/actions/train/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0a5-slim-bullseye
+FROM python:3.8-slim
 ADD . /app
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
 ENV ENVOY_ADMIN_API=http://localhost:15000

--- a/EndToEndExample/actions/train/train.py
+++ b/EndToEndExample/actions/train/train.py
@@ -111,7 +111,7 @@ def train(params):
     conn_params = {}
     for p in connection['params']:
         conn_params.update({p['name']: p['value']})
-    print(conn_params)
+    print({k:v for k,v in conn_params.items() if v not in ('secretKey', 'publicKey')})
     uri = conn_params["uri"]
 
     # Download training data using connection


### PR DESCRIPTION
I've been trying to run this example, but I keep getting compilation errors (installing numpy) when building the `train` docker image. 

Saw this was changed for a security scan in #87 , but I think it is not a good idea to use an alpha version of Python 3.11 in the base image because the packages in `requirements.txt` are pinned to versions released for Python 3.7 - 3.9/3.10. I tried lowering the base image to `python:3.9-slim` but got a similar compilation error, so I instead went with Python 3.8.

For reference, on [PyPI](https://pypi.org/project/pandas/1.3.0/#files) Pandas has pre-built wheels for python 3.7 - 3.9.

And from, https://numpy.org/devdocs/release/1.22.0-notes.html

> The Python versions supported in this release are 3.8-3.10, Python 3.7 has been dropped.

---- 

Failure with Python 3.11
```
#9 34.21       RuntimeError: Broken toolchain: cannot link a simple C program
#9 34.21       ----------------------------------------
#9 34.21   WARNING: Discarding https://files.pythonhosted.org/packages/cb/c0/7b3d69e6ee68bc54c97ba51f8c3c3e43ff1dbc7bd97347cc19a1f944e60a/numpy-1.19.3.zip#sha256=35bf5316af8dc7c7db1ad45bec603e5fb28671beb98ebd1d65e8059efcfd3b72 (from https://pypi.org/simple/numpy/) (requires-python:>=3.6). Command errored out with exit status 1: /usr/local/bin/python /tmp/tmpy3m3zkl7_in_process.py prepare_metadata_for_build_wheel /tmp/tmpjpecn9yo Check the logs for full command output.
#9 34.21   ERROR: Could not find a version that satisfies the requirement numpy==1.19.3 (from versions: 1.3.0, 1.4.1, 1.5.0, 1.5.1, 1.6.0, 1.6.1, 1.6.2, 1.7.0, 1.7.1, 1.7.2, 1.8.0, 1.8.1, 1.8.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.10.0.post2, 1.10.1, 1.10.2, 1.10.4, 1.11.0, 1.11.1, 1.11.2, 1.11.3, 1.12.0, 1.12.1, 1.13.0rc1, 1.13.0rc2, 1.13.0, 1.13.1, 1.13.3, 1.14.0rc1, 1.14.0, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0rc1, 1.15.0rc2, 1.15.0, 1.15.1, 1.15.2, 1.15.3, 1.15.4, 1.16.0rc1, 1.16.0rc2, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5, 1.16.6, 1.17.0rc1, 1.17.0rc2, 1.17.0, 1.17.1, 1.17.2, 1.17.3, 1.17.4, 1.17.5, 1.18.0rc1, 1.18.0, 1.18.1, 1.18.2, 1.18.3, 1.18.4, 1.18.5, 1.19.0rc1, 1.19.0rc2, 1.19.0, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.19.5, 1.20.0rc1, 1.20.0rc2, 1.20.0, 1.20.1, 1.20.2, 1.20.3, 1.21.0rc1, 1.21.0rc2, 1.21.0, 1.21.1, 1.22.0rc1, 1.22.0rc2, 1.22.0rc3, 1.22.0, 1.22.1, 1.22.2, 1.22.3)
#9 34.21   ERROR: No matching distribution found for numpy==1.19.3
#9 34.21   WARNING: You are using pip version 21.2.4; however, version 22.0.4 is available.
#9 34.21   You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#9 34.21   ----------------------------------------
#9 34.21 WARNING: Discarding https://files.pythonhosted.org/packages/53/05/bf382e8bc60731906a2e7261648bcea3a6b309ad2b9952010737a1b9413e/pandas-1.3.0.tar.gz#sha256=c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2 (from https://pypi.org/simple/pandas/) (requires-python:>=3.7.1). Command errored out with exit status 1: /usr/local/bin/python /tmp/pip-standalone-pip-b38mhqur/__env_pip__.zip/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-32_l9t29/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=38.6.0' wheel 'Cython>=0.29.21,<3' 'numpy==1.17.3; python_version=='"'"'3.7'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.18.3; python_version=='"'"'3.8'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.19.3; python_version>='"'"'3.9'"'"' and (platform_machine!='"'"'arm64'"'"' or platform_system!='"'"'Darwin'"'"') and platform_machine!='"'"'aarch64'"'"'' 'numpy==1.19.2; python_version=='"'"'3.7'"'"' and platform_machine=='"'"'aarch64'"'"'' 'numpy==1.19.2; python_version=='"'"'3.8'"'"' and platform_machine=='"'"'aarch64'"'"'' 'numpy>=1.20.0; python_version=='"'"'3.8'"'"' and platform_machine=='"'"'arm64'"'"' and platform_system=='"'"'Darwin'"'"'' 'numpy>=1.20.0; python_version=='"'"'3.9'"'"' and platform_machine=='"'"'arm64'"'"' and platform_system=='"'"'Darwin'"'"'' Check the logs for full command output.
#9 34.21 ERROR: Could not find a version that satisfies the requirement pandas==1.3.0 (from versions: 0.1, 0.2, 0.3.0, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.5.0, 0.6.0, 0.6.1, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.11.0, 0.12.0, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.15.0, 0.15.1, 0.15.2, 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.17.1, 0.18.0, 0.18.1, 0.19.0, 0.19.1, 0.19.2, 0.20.0, 0.20.1, 0.20.2, 0.20.3, 0.21.0, 0.21.1, 0.22.0, 0.23.0, 0.23.1, 0.23.2, 0.23.3, 0.23.4, 0.24.0, 0.24.1, 0.24.2, 0.25.0, 0.25.1, 0.25.2, 0.25.3, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.4.0rc0, 1.4.0, 1.4.1, 1.4.2)
#9 34.22 ERROR: No matching distribution found for pandas==1.3.0
#9 34.22 WARNING: You are using pip version 21.2.4; however, version 22.0.4 is available.
#9 34.22 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install -r /app/requirements.txt]: exit code: 1
```

Failure with Python 3.9
```
#10 18.79             compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -I/usr/local/include/python3.9 -c'
#10 18.79             gcc: _configtest.c
#10 18.79             failure.
#10 18.79             removing: _configtest.c _configtest.o
#10 18.79             Traceback (most recent call last):
#10 18.79               File "<string>", line 2, in <module>
#10 18.79               File "<pip-setuptools-caller>", line 34, in <module>
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/setup.py", line 443, in <module>
#10 18.79                 setup_package()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/setup.py", line 435, in setup_package
#10 18.79                 setup(**metadata)
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/core.py", line 171, in setup
#10 18.79                 return old_setup(**new_attr)
#10 18.79               File "/usr/local/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
#10 18.79                 return distutils.core.setup(**attrs)
#10 18.79               File "/usr/local/lib/python3.9/distutils/core.py", line 148, in setup
#10 18.79                 dist.run_commands()
#10 18.79               File "/usr/local/lib/python3.9/distutils/dist.py", line 966, in run_commands
#10 18.79                 self.run_command(cmd)
#10 18.79               File "/usr/local/lib/python3.9/distutils/dist.py", line 985, in run_command
#10 18.79                 cmd_obj.run()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/install.py", line 62, in run
#10 18.79                 r = self.setuptools_run()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/install.py", line 36, in setuptools_run
#10 18.79                 return distutils_install.run(self)
#10 18.79               File "/usr/local/lib/python3.9/distutils/command/install.py", line 546, in run
#10 18.79                 self.run_command('build')
#10 18.79               File "/usr/local/lib/python3.9/distutils/cmd.py", line 313, in run_command
#10 18.79                 self.distribution.run_command(command)
#10 18.79               File "/usr/local/lib/python3.9/distutils/dist.py", line 985, in run_command
#10 18.79                 cmd_obj.run()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/build.py", line 47, in run
#10 18.79                 old_build.run(self)
#10 18.79               File "/usr/local/lib/python3.9/distutils/command/build.py", line 135, in run
#10 18.79                 self.run_command(cmd_name)
#10 18.79               File "/usr/local/lib/python3.9/distutils/cmd.py", line 313, in run_command
#10 18.79                 self.distribution.run_command(command)
#10 18.79               File "/usr/local/lib/python3.9/distutils/dist.py", line 985, in run_command
#10 18.79                 cmd_obj.run()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/build_src.py", line 142, in run
#10 18.79                 self.build_sources()
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/build_src.py", line 153, in build_sources
#10 18.79                 self.build_library_sources(*libname_info)
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/build_src.py", line 286, in build_library_sources
#10 18.79                 sources = self.generate_sources(sources, (lib_name, build_info))
#10 18.79               File "/tmp/pip-install-3b5hz3a0/numpy_c9fe600e3651435795e7605413b8cab6/numpy/distutils/command/build_src.py", line 369, in generate_sources
#10 18.79                 source = func(extension, build_dir)
#10 18.79               File "numpy/core/setup.py", line 669, in get_mathlib_info
#10 18.79                 raise RuntimeError("Broken toolchain: cannot link a simple C program")
#10 18.79             RuntimeError: Broken toolchain: cannot link a simple C program
#10 18.79             [end of output]
#10 18.79
#10 18.79         note: This error originates from a subprocess, and is likely not a problem with pip.
#10 18.79       error: legacy-install-failure
#10 18.79
#10 18.79       × Encountered error while trying to install package.
#10 18.79       ╰─> numpy
#10 18.79
#10 18.79       note: This is an issue with the package mentioned above, not pip.
#10 18.79       hint: See above for output from the failure.
#10 18.79       [end of output]
#10 18.79
#10 18.79   note: This error originates from a subprocess, and is likely not a problem with pip.
#10 18.81 error: subprocess-exited-with-error
#10 18.81
#10 18.81 × pip subprocess to install build dependencies did not run successfully.
#10 18.81 │ exit code: 1
#10 18.81 ╰─> See above for output.
#10 18.81
#10 18.81 note: This error originates from a subprocess, and is likely not a problem with pip.
------
executor failed running [/bin/sh -c pip install -r /app/requirements.txt]: exit code: 1
```