### PR TITLE
add the end to end example into the build script

### DIFF
--- a/EndToEndExample/actions/predict/Dockerfile
+++ b/EndToEndExample/actions/predict/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.8-slim
 ADD . /app
 WORKDIR /app
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 .PHONY:build push deploy tests get all
-EXAMPLES := ai-missions/high-risk-flu-shot-mission/skills batch-prediction online-prediction jdbc-example ExperimentsExample InterventionSkillExample
+EXAMPLES := ai-missions/high-risk-flu-shot-mission/skills batch-prediction online-prediction jdbc-example ExperimentsExample InterventionSkillExample EndToEndExample
 export PROJECT_NAME=test
 export DOCKER_PREGISTRY_URL=test
 


### PR DESCRIPTION
the EndToEndExample image isn't able to build and this is causing some issues in the `dci-dev` pipeline.
I tried a couple generic fixes but wasn't able to figure out what the correct combination was to get this predict image build successfully.
```
cd cortex-fabric-examples/EndToEndExample/actions/predict && docker build .
```