### PR TITLE
Fix typo in directory name in GCS connection skill example

### DIFF
--- a/cortex-python-lib-examples/gcs-connection-skill/docs/gcs-connection-skill/README.md
+++ b/cortex-python-lib-examples/gcs-connection-skill/docs/gcs-connection-skill/README.md
@@ -1,7 +1,7 @@
 ### Cortex-Python Library Example: GCS Connection Example
 
-Cortex Skill (job) example for working with a GCS Cortex Connection. This demonstrates:
-* Creating a Cortex Secret named `gcs-service-key`
+Cortex Skill (job) example for working with a Google Cloud Storage (GCS) Cortex Connection. This demonstrates:
+* Creating a Cortex Secret named `gcs-service-key` with the service account key
 * Creating a Cortex Connection to Google Cloud Storage (GCS)
 * Using the GCS Connection in a Skill
   - See `gcs-connection-skill/main.py` for how to use a Cortex Connections in a Skill. The skill gets the connection from Cortex and uses the `google-cloud-storage` package (https://pypi.org/project/google-cloud-storage/) to read the contents of the connection.

--- a/cortex-python-lib-examples/gcs-connection-skill/skills/Makefile
+++ b/cortex-python-lib-examples/gcs-connection-skill/skills/Makefile
@@ -6,7 +6,7 @@ DOCKER_PREGISTRY_URL=private-registry.dci-dev.dev-eks.insights.ai
 DOCKER_IMAGE_URL=${DOCKER_PREGISTRY_URL}/${ACTION_NAME}:${TAG}
 
 build: check-env
-	docker build --no-cache -t ${DOCKER_IMAGE_URL} -f gcs-connection-skill/Dockerfile gcs-connection-skill/
+	docker build --no-cache -t ${DOCKER_IMAGE_URL} -f gcs-connection-reader/Dockerfile gcs-connection-reader/
 
 push: check-env
 	docker push ${DOCKER_IMAGE_URL}
@@ -15,7 +15,7 @@ deploy: install build push
 	cortex skills save skill.json
 
 install: 
-	pip install -r gcs-connection-skill/requirements.txt
+	pip install -r gcs-connection-reader/requirements.txt
 
 tests: check-env
 	cortex skills invoke --params-file ./payload.json ${SKILL_NAME} params


### PR DESCRIPTION
Had noticed this typo before the demo, think I had renamed the folder at the last second but forgot to update the Makefile