### PR TITLE
allow overriding the skill name if it's set in the environment

### DIFF
--- a/online-prediction/Makefile
+++ b/online-prediction/Makefile
@@ -1,5 +1,5 @@
 IMAGE_TAG=latest
-SKILL_NAME=$(notdir $(CURDIR))
+SKILL_NAME=${SKILL_NAME:-$(notdir $(CURDIR))}
 DOCKER_IMAGE_URL=${DOCKER_PREGISTRY_URL}/${SKILL_NAME}:${IMAGE_TAG}
 
 init: check-env


### PR DESCRIPTION
this is causing false positives in the test pipelines (and failing completely when run in `dci-integration`).. the automated tests only pass when the `online-prediction` skill is deployed into the `shared` project separately, [the tests actually change the skill name](https://github.com/CognitiveScale/c12e-cortex-api-tests/blob/develop/tests/python_lib/test_online_prediction.py#L30) to `online-prediction-s1` which gets built and deployed but ultimately fails when we hit `get` from the `make all` command because it's still looking for `cortex skills describe online-prediction --project composetests`