### PR TITLE
FAB-4346 spark_submit script with pod driver template

### DIFF
--- a/profiles-sdk-examples/main-app/src/main/resources/conf/driverTemplate.yaml
+++ b/profiles-sdk-examples/main-app/src/main/resources/conf/driverTemplate.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  ownerReferences:
+    - apiVersion: v1
+      controller: true
+      kind: Pod
+      name: ${CONTROLLER_NAME}
+      uid: ${CONTROLLER_UID}
+spec:
+  containers:
+    - name: spark-kubernetes-driver

--- a/profiles-sdk-examples/main-app/src/main/resources/python/submit_job.py
+++ b/profiles-sdk-examples/main-app/src/main/resources/python/submit_job.py
@@ -112,17 +112,19 @@ if __name__ == '__main__':
         input_params = payload['payload']
         n = len(sys.argv)
         # TODO throw error if wrong amount of args
-        spark_config = input_params.get("spark_config")
-        if not spark_config:
-            # get resource files from filesystem
-            config_file_loc = input_params.get("config")
-            spark_config = get_config_file(config_file_loc)
+        config_file_loc = input_params.get("config")
+        # get resource files from filesystem
+        spark_config = get_config_file(config_file_loc)
 
-        app_config = input_params.get("app_config")
-        if app_config:
-            with open("/opt/spark/conf/app-conf.json", 'w') as file:
-                file.write(json.dumps(app_config))
+        # TODO: Verify app command is a list of strings
+        override_app_command = input_params.get("app_command")
+        if override_app_command:
+            spark_config.get("pyspark", {})["app_command"] = override_app_command
 
+        # TODO: Verify conf overrides is a dict
+        config_option_overrides = input_params.get("conf")
+        if config_option_overrides:
+            spark_config.get("pyspark", {}).get("options", {}).get("--conf", {}).update(config_option_overrides)
         driver_template = get_driver_template("/app/conf/driverTemplate.yaml")
 
         # variable replace and write new driver podspec

--- a/profiles-sdk-examples/main-app/src/main/resources/python/submit_job.py
+++ b/profiles-sdk-examples/main-app/src/main/resources/python/submit_job.py
@@ -8,7 +8,7 @@ import yaml
 import sys
 import json
 
-def get_runtime_args(config, token):
+def get_runtime_args(config, token, url):
     pyspark_args = config['pyspark']
     options = pyspark_args['options']
     args = [os.environ['SPARK_HOME'] + "/" + pyspark_args['pyspark_bin']]
@@ -26,6 +26,13 @@ def get_runtime_args(config, token):
     args.append(f"spark.kubernetes.driverEnv.CORTEX_TOKEN={token}")
     args.append('--conf')
     args.append(f"spark.cortex.phoenix.token={token}")
+    args.append('--conf')
+    args.append(f"spark.kubernetes.driver.podTemplateFile=driverSpec.yaml")
+    args.append('--conf')
+    args.append(f"spark.kubernetes.executor.podTemplateContainerName=spark-kubernetes-driver")
+    if url:
+        args.append('--conf')
+        args.append(f"spark.fabric.client.phoenix.url={url}")
     args.append(pyspark_args['app_location'])
     for x in pyspark_args['app_command']:
         args.append(x)
@@ -88,33 +95,47 @@ class LogMessage:
                 current_container = ''
         return instance
 
+def get_driver_template(driver_file_loc):
+    with open(driver_file_loc) as yaml_file:
+        return yaml_file.read()
+
+def write_driver(driver_spec_loc, driver_spec):
+    with open(driver_spec_loc, 'w') as file:
+        file.write(driver_spec)
 
 if __name__ == '__main__':
     try:
         # pool values from args
-        token = os.environ['CORTEX_TOKEN']
-
         payload = json.loads(sys.argv[1])
+        token = payload.get('token') or os.environ['CORTEX_TOKEN']
+        print(payload)
         input_params = payload['payload']
-
         n = len(sys.argv)
         # TODO throw error if wrong amount of args
-        config_file_loc = input_params.get("config")
-        # get resource files from filesystem
-        spark_config = get_config_file(config_file_loc)
+        spark_config = input_params.get("spark_config")
+        if not spark_config:
+            # get resource files from filesystem
+            config_file_loc = input_params.get("config")
+            spark_config = get_config_file(config_file_loc)
 
-        # TODO: Verify app command is a list of strings
-        override_app_command = input_params.get("app_command")
-        if override_app_command:
-            spark_config.get("pyspark", {})["app_command"] = override_app_command
+        app_config = input_params.get("app_config")
+        if app_config:
+            with open("/opt/spark/conf/app-conf.json", 'w') as file:
+                file.write(json.dumps(app_config))
 
-        # TODO: Verify conf overrides is a dict
-        config_option_overrides = input_params.get("conf")
-        if config_option_overrides:
-            spark_config.get("pyspark", {}).get("options", {}).get("--conf", {}).update(config_option_overrides)
+        driver_template = get_driver_template("/app/conf/driverTemplate.yaml")
+
+        # variable replace and write new driver podspec
+        # TODO better job of generalizing
+        driver_variables = {
+            'CONTROLLER_NAME': os.environ.get('POD_NAME', "None"),
+            'CONTROLLER_UID': os.environ.get('POD_UID', "None")
+        }
+        driver_spec = replace_template_variables(driver_template, driver_variables)
+        write_driver("driverSpec.yaml", driver_spec)
 
         # create spark-submit call
-        run_args = get_runtime_args(spark_config, token)
+        run_args = get_runtime_args(spark_config, token, payload.get('apiEndpoint'))
 
         print(run_args)
 

--- a/profiles-sdk-examples/templates/podspec.yaml
+++ b/profiles-sdk-examples/templates/podspec.yaml
@@ -1,2 +1,14 @@
 - path: '/containers/0/imagePullPolicy'
   value: "Always"
+- path: '/containers/0/env/-'
+  value:
+    name: POD_UID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+- path: '/containers/0/env/-'
+  value:
+    name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name


### PR DESCRIPTION
Requirement is that the spark-submit skill can be deleted for long running jobs like streaming data source and that the spark driver associated with it would be deleted as well.

Also have this fix supported for the profiles-sdk, waiting to push that up for review as Colton is moving the repo.

Add pod info as env vars on spark-submit pod (best way I could find to do this)
Use pod info to set owner reference on driver by var replace on driverTemplate.yaml
Verified that the spark driver is now has the controlled by field set pointing back to the spark-submit pod. If the spark-submit pod is deleted, then the spark-driver is also deleted (and the executors as well)